### PR TITLE
Remove leftover  mperror variable

### DIFF
--- a/src/mempool.c
+++ b/src/mempool.c
@@ -26,8 +26,6 @@
 
 #include "mempool.h"
 
-mp_error_t mp_error;
-
 struct block {
     void *next;
 };


### PR DESCRIPTION
Looks like this stuff was removed in a previous commit. This line is just a left over.

This causes it to fail build as mp_error_t  is not typedef anymore.

Thanks for this neat little lib.